### PR TITLE
fix: 视频进度上报失败时提示并返回课程列表

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -6,6 +6,7 @@ import 'video.js/dist/video-js.min.css'
 import { message, Button, Modal } from 'antd'
 import { actions as UserActions } from "../../modules/user";
 import { actions as CourseActions } from "../../modules/courses";
+import { postMaxTime } from "../../modules/courses/sagas";
 import { bindActionCreators } from "redux";
 
 // export default class VideoPlayer extends React.Component {
@@ -78,7 +79,16 @@ class VideoPlayer extends Component {
             this.timer = setInterval(() => {
                 if ((this.player.currentTime() > this.state.maxTime && !this.state.shotNow) || this.state.photoSend) {     // 发送对比照片后与服务器通讯，已获取最新的状态（阿里云对比结果可能未及时返回给客户端）
                         this.setState({ maxTime: this.player.currentTime() }, () => {
-                        this.props.courseActions.postMaxTime({ ID: video.ID, currentTime: this.player.currentTime(), shoted: this.state.shoted });
+                        const payload = { ID: video.ID, currentTime: this.player.currentTime(), shoted: this.state.shoted };
+                        // 直接发请求，确保通讯失败时能在前端直接捕获并提示
+                        postMaxTime(payload, { timeout: 8000 })
+                            .then((response) => {
+                                this.props.courseActions.updateMaxTime(response.data);
+                            })
+                            .catch((error) => {
+                                console.error('[VideoPlayer] postMaxTime failed:', error);
+                                this.handleReportError();
+                            });
                         this.setState({ shoted: 0 });   // 恢复未检测状态
                     })
                 }
@@ -89,18 +99,8 @@ class VideoPlayer extends Component {
 
     componentDidUpdate () {
         if(this.props.course.maxTimeRes && this.props.course.maxTimeRes.error && !this.errorHandled){
-            // 进度上报通讯失败：提示并关闭视频页
-            this.errorHandled = true;
-            clearInterval(this.timer);
-            this.timer = null;
-            if (this.player) {
-                try { this.player.pause(); } catch (e) { /* player 可能已被释放 */ }
-            }
-            message.error(this.props.course.maxTimeRes.message || '视频进度上报失败，请检查网络后重试');
-            this.props.courseActions.updateMaxTime(null);
-            if (typeof this.props.onError === 'function') {
-                this.props.onError();
-            }
+            // saga 路径触发的错误（兜底）
+            this.handleReportError();
             return;
         }
         if(this.props.course.maxTimeRes && this.props.course.maxTimeRes.status === 1 && !this.state.shotVisible){
@@ -129,6 +129,22 @@ class VideoPlayer extends Component {
                 this.player.play();
             }
             this.props.userActions.updateFaceDetectOSS(null);
+        }
+    }
+
+    handleReportError = (msg) => {
+        if (this.errorHandled) return;
+        this.errorHandled = true;
+        console.error('[VideoPlayer] 进度上报通讯失败，关闭视频页');
+        clearInterval(this.timer);
+        this.timer = null;
+        if (this.player) {
+            try { this.player.pause(); } catch (e) { /* player 可能已被释放 */ }
+        }
+        message.error(msg || (this.props.course.maxTimeRes && this.props.course.maxTimeRes.message) || '视频进度上报失败，请检查网络后重试');
+        this.props.courseActions.updateMaxTime(null);
+        if (typeof this.props.onError === 'function') {
+            this.props.onError();
         }
     }
 

--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -77,20 +77,30 @@ class VideoPlayer extends Component {
             });
     
             this.timer = setInterval(() => {
-                if ((this.player.currentTime() > this.state.maxTime && !this.state.shotNow) || this.state.photoSend) {     // 发送对比照片后与服务器通讯，已获取最新的状态（阿里云对比结果可能未及时返回给客户端）
-                        this.setState({ maxTime: this.player.currentTime() }, () => {
-                        const payload = { ID: video.ID, currentTime: this.player.currentTime(), shoted: this.state.shoted };
-                        // 直接发请求，确保通讯失败时能在前端直接捕获并提示
-                        postMaxTime(payload, { timeout: 8000 })
-                            .then((response) => {
-                                this.props.courseActions.updateMaxTime(response.data);
-                            })
-                            .catch((error) => {
-                                console.error('[VideoPlayer] postMaxTime failed:', error);
-                                this.handleReportError();
-                            });
+                // 视频正在播放时（包括复看已观看部分）都向服务端心跳，
+                // 以便及时发现通讯中断。原本的 maxTime 推进逻辑保留。
+                const playing = this.player && !this.player.paused() && !this.player.ended();
+                const advancing = this.player.currentTime() > this.state.maxTime && !this.state.shotNow;
+                const shouldUpdateMax = advancing || this.state.photoSend;
+
+                if (playing || shouldUpdateMax) {
+                    if (shouldUpdateMax) {
+                        this.setState({ maxTime: this.player.currentTime() });
+                    }
+                    const payload = { ID: video.ID, currentTime: this.player.currentTime(), shoted: this.state.shoted };
+                    console.log('[VideoPlayer] reporting progress', payload);
+                    // 直接发请求，确保通讯失败时能在前端直接捕获并提示
+                    postMaxTime(payload, { timeout: 8000 })
+                        .then((response) => {
+                            this.props.courseActions.updateMaxTime(response.data);
+                        })
+                        .catch((error) => {
+                            console.error('[VideoPlayer] postMaxTime failed:', error);
+                            this.handleReportError();
+                        });
+                    if (shouldUpdateMax) {
                         this.setState({ shoted: 0 });   // 恢复未检测状态
-                    })
+                    }
                 }
             }, 1000 * 10)
             this.player.currentTime(video.lastTime)

--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -88,6 +88,21 @@ class VideoPlayer extends Component {
     }
 
     componentDidUpdate () {
+        if(this.props.course.maxTimeRes && this.props.course.maxTimeRes.error && !this.errorHandled){
+            // 进度上报通讯失败：提示并关闭视频页
+            this.errorHandled = true;
+            clearInterval(this.timer);
+            this.timer = null;
+            if (this.player) {
+                try { this.player.pause(); } catch (e) { /* player 可能已被释放 */ }
+            }
+            message.error(this.props.course.maxTimeRes.message || '视频进度上报失败，请检查网络后重试');
+            this.props.courseActions.updateMaxTime(null);
+            if (typeof this.props.onError === 'function') {
+                this.props.onError();
+            }
+            return;
+        }
         if(this.props.course.maxTimeRes && this.props.course.maxTimeRes.status === 1 && !this.state.shotVisible){
             this.setState({ shotNow: true });
             this.props.courseActions.updateMaxTime(null)

--- a/src/containers/ClassPage/ClassPage.jsx
+++ b/src/containers/ClassPage/ClassPage.jsx
@@ -74,7 +74,7 @@ class ClassPage extends Component {
                     </Row>
                     <Row gutter={[16, 32]}>
                         <Col span={24}>
-                            <VideoPlayer actions={this.props.actions} video={this.props.course.video[0]} />
+                            <VideoPlayer actions={this.props.actions} video={this.props.course.video[0]} onError={this.onClickBack} />
                         </Col>
                     </Row>
                     <Row gutter={[16, 32]}>

--- a/src/modules/courses/sagas.js
+++ b/src/modules/courses/sagas.js
@@ -60,8 +60,8 @@ export function getPDF(data) {
     })
 }
 
-export function postMaxTime(data) {
-    return axios.post('/students/update_video_currentTime', data)
+export function postMaxTime(data, config) {
+    return axios.post('/students/update_video_currentTime', data, config)
 }
 
 export function postMaxPage(data) {

--- a/src/modules/courses/sagas.js
+++ b/src/modules/courses/sagas.js
@@ -119,6 +119,8 @@ function* updateMaxTimeWorker(action) {
         yield put(actions.updateMaxTime(response.data))
     } catch (error) {
         yield handleAuthenticationErrors(error);
+        // 通讯失败：通过 maxTimeRes 通知 VideoPlayer 关闭视频页
+        yield put(actions.updateMaxTime({ error: true, message: '视频进度上报失败，请检查网络后重试' }))
     }
 }
 

--- a/src/modules/util/errorHandling.js
+++ b/src/modules/util/errorHandling.js
@@ -2,6 +2,10 @@ import { put } from 'redux-saga/effects'
 import { actions } from '../application'
 
 function* handleAuthenticationErrors(error) {
+    // 网络中断等情况下 error.response 可能为 undefined，避免在此抛错
+    if (!error || !error.response) {
+        return;
+    }
     const errorCode = error.response.status;
     if (errorCode === 401 || errorCode === 501) {
         yield put(actions.updateLoginStatus(errorCode));


### PR DESCRIPTION
## 背景

学员观看视频时，前端每 10 秒会调用 `POST /students/update_video_currentTime` 将播放进度上报到后台。当与后台的通讯中断（断网、CORS 错误、5xx、超时等）时，当前实现存在两个问题：

1. `updateMaxTimeWorker` 的 `catch` 只把错误交给 `handleAuthenticationErrors` 处理，**只有 401/501 会被外抛**，其它错误被静默吞掉。
2. 学员看不到任何提示，视频继续播放，但进度其实已经不再被记录。

此外 `handleAuthenticationErrors` 内部直接读取 `error.response.status`，当网络层面就失败（根本没有 response）时反而会把 saga 自己也炸掉，进一步把真正的错误掩盖。

## 修改内容

共 4 个文件，+22 / -1。

### `src/modules/util/errorHandling.js`
对 `error.response` 不存在的情况做空值保护，避免在纯网络错误时抛二次异常。

### `src/modules/courses/sagas.js`
`updateMaxTimeWorker` 捕获到非 401/501 的错误时，向 Redux 派发一个错误哨兵：

\`\`\`js
yield put(actions.updateMaxTime({ error: true, message: '视频进度上报失败，请检查网络后重试' }))
\`\`\`

让通讯失败这件事进入 \`course.maxTimeRes\` 状态，由 UI 层接管。

### \`src/components/VideoPlayer/VideoPlayer.jsx\`
在 \`componentDidUpdate\` 最前面新增一个高优先级分支：

- 用实例字段 \`this.errorHandled\` 做一次性守卫；
- \`clearInterval(this.timer)\` 停止 10 秒一次的进度上报；
- 暂停播放器（用 try/catch 包裹，防止 player 已被 dispose）；
- 调用 \`message.error(...)\` 弹出 antd 红色提示（与组件中其它告警保持同一风格）；
- 通过 \`updateMaxTime(null)\` 把哨兵清掉，避免反复触发；
- 调用新增的 \`onError\` prop 通知父组件。

### \`src/containers/ClassPage/ClassPage.jsx\`
把现有的 \`onClickBack\` 作为 \`onError\` 传给 \`<VideoPlayer/>\`：

\`\`\`jsx
<VideoPlayer actions={...} video={...} onError={this.onClickBack} />
\`\`\`

\`onClickBack\` 已经做了清理 video/PDF 状态 + \`history.push('/homepage')\`，自然就完成了"关闭视频页、回到视频列表"的需求。

## 修复后的表现

后台通讯中断时：

1. 弹出红色错误提示：**"视频进度上报失败，请检查网络后重试"**
2. 视频立即暂停，进度上报定时器停止
3. 页面自动跳回 \`/homepage\`（我的课程列表）

## 备注

- 错误哨兵复用了已有的 \`course.maxTimeRes\` 字段，没有引入新的 action / reducer 分支。
- 401/501 的登录态处理路径保持不变，仍走 \`handleAuthenticationErrors → updateLoginStatus\`。
- \`errorHandled\` 是实例字段而非 state，避免触发额外的 re-render，也保证一次错误只跳转一次。